### PR TITLE
Add some missing type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ pom.xml
 /classes/
 .lein-failures
 .lein-deps-sum
+.nrepl*
+target*
 *~
 *#
 .#*

--- a/src/zookeeper/data.clj
+++ b/src/zookeeper/data.clj
@@ -7,8 +7,8 @@
   `(let [bytes# (make-array Byte/TYPE ~size)
          buf# (-> (ByteBuffer/allocateDirect ~size)
                   (~f ~value)
-                  .clear
-                  (.get bytes# 0 ~size))]
+                  .clear)]
+     (.get ^java.nio.ByteBuffer buf# bytes# 0 ~size)
      bytes#))
 
 (defprotocol ByteConverter
@@ -74,4 +74,3 @@
 (defn to-char
   ([bytes]
    (.getChar (ByteBuffer/wrap bytes))))
-

--- a/src/zookeeper/internal.clj
+++ b/src/zookeeper/internal.clj
@@ -25,7 +25,7 @@
 
 (defn stat-to-map
   ([^org.apache.zookeeper.data.Stat stat]
-     ;;(long czxid, long mzxid, long ctime, long mtime, int version, int cversion, int aversion, long ephemeralOwner, int dataLength, int numChildren, long pzxid)
+   ;;(long czxid, long mzxid, long ctime, long mtime, int version, int cversion, int aversion, long ephemeralOwner, int dataLength, int numChildren, long pzxid)
    (when stat
      {:czxid (.getCzxid stat)
       :mzxid (.getMzxid stat)
@@ -48,7 +48,7 @@
 
 ;; Watcher
 
-(defn make-watcher
+(defn ^Watcher make-watcher
   ([handler]
    (reify Watcher
      (process [this event]
@@ -65,7 +65,7 @@
                  :context context
                  :name name})))))
 
-(defn stat-callback
+(defn ^AsyncCallback$StatCallback stat-callback
   ([handler]
    (reify AsyncCallback$StatCallback
      (processResult [this return-code path context stat]
@@ -92,7 +92,7 @@
                  :path path
                  :context context})))))
 
-(defn data-callback
+(defn ^AsyncCallback$DataCallback data-callback
   ([handler]
    (reify AsyncCallback$DataCallback
      (processResult [this return-code path context data stat]
@@ -153,7 +153,7 @@
            :auth-ids ZooDefs$Ids/AUTH_IDS ;; This Id is only usable to set ACLs
            :creator-all-acl ZooDefs$Ids/CREATOR_ALL_ACL ;; This ACL gives the creators authentication id's all permissions
            :read-all-acl ZooDefs$Ids/READ_ACL_UNSAFE ;; This ACL gives the world the ability to read
-})
+           })
 
 (defn event-types
   ":NodeDeleted :NodeDataChanged :NodeCreated :NodeChildrenChanged :None"
@@ -166,4 +166,3 @@
 (defn client-states
   ":AUTH_FAILED :CLOSED :CONNECTED :ASSOCIATING :CONNECTING"
   ([] (into #{} (map #(keyword (.toString ^ZooKeeper$States %)) (ZooKeeper$States/values)))))
-


### PR DESCRIPTION
@ghoseb this is a dummy PR. Please review it. We can raise an upstream PR if you think the changes are ok. This removes all reflection warnings in `zookeeper.clj` which is what most clients would use I think. There are still some left in `data.clj` but resolving them is not so straightforward. Adding more comments there.

But I ran some benchmarks with `criterium` and the performance improvements were not that much. Do you think these should be tested in some other way, or only this much gain is expected ?

API methods affected by the change:
  - create
  Time reduced by about 15 µs of 270 µs (5.6 %)

  - children
  Time reduced by about 10 µs of 250 µs (4 %)

  - data
  Time reduced by about 10 µs of 130 µs (7.7 %)

  - add-auth-info

  - compare-and-set-data